### PR TITLE
Remove private.el and early-init-private.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ projectile-bookmarks.eld
 bookmarks
 auto-save-list/
 README.html
+private.el
+early-init-private.el

--- a/README.org
+++ b/README.org
@@ -102,7 +102,7 @@ It works, but it is not built for terminal use, since one of the Core Principles
 
 *Why is it called Castlemacs?* See [[#why-this-name][Why this name?]]
 
-*Where do I store my private config?* You can store your regular private config in =private.el=. This file will not be changed in Castlemacs, so you don't have worry about conflicts.
+*Where do I store my private config?* You can store your regular private config in =~/.emacs.d/private.el=. This file will not be changed in Castlemacs, so you don't have worry about conflicts.
 
 * Installation
 

--- a/early-init-private.el
+++ b/early-init-private.el
@@ -1,2 +1,0 @@
-;; This is your private configuration file for pre-init things. It is loaded automatically, so feel free to add whatever you want.
-;; This file will not be affected by Castlemacs updates.

--- a/private.el
+++ b/private.el
@@ -1,2 +1,0 @@
-;; This is your private configuration file. It is loaded automatically, so feel free to add whatever you want.
-;; This file will not be affected by Castlemacs updates.


### PR DESCRIPTION
Thought it might be worthwhile removing them from version control. I also noticed that the `early-int-private.el` isn't being used. Or did I miss something?